### PR TITLE
Cleaned up music

### DIFF
--- a/Assets/audio/80_4.ogg
+++ b/Assets/audio/80_4.ogg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81664e99c8461dd43a8994d5102d4284e68f332f64746448b62fddf74aed47cc
-size 844824
+oid sha256:2e5c21a74422111b2592cd10ad1c60f298cc8cf65c59f664f7c40046cb2f23da
+size 837851

--- a/Assets/audio/80_4_synth1.ogg
+++ b/Assets/audio/80_4_synth1.ogg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:311b7ae46a73ec5c5eb09f1e38ff42f2dc32decd0b7309efc0aa1665532651b3
-size 1215987
+oid sha256:dc33e62cc86c5449b5f43aacb4dd29ce71502d048bebcad64c984185c4bd73d3
+size 1205752

--- a/Assets/audio/80_4_synth2.ogg
+++ b/Assets/audio/80_4_synth2.ogg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82ac99adf235e94cf54417e5dc8a5b614e4ebd8ec80e56758aed9fe08783e280
-size 1062285
+oid sha256:72dabec78787c81bed21a82d07ad68336369094c81071552d6ea9455b32ee48e
+size 1062706


### PR DESCRIPTION
- De-humanizes 8-bit off-beat synth. Previously some notes in the arpeggiator were holding over in a way that made me cringe, and their lengths varied in a way that didn't make stylistic sense.
- Quantizes bass line. There were some bass notes that were anticipating the beat.
- Altered melody synth instruments to match HOPO sections by smoothing out the pitch changes in those sections. If you could, give it a listen. It's slightly different in that those sections are less punchy, but the benefit is that the visual and sound match better now.

closes #71 
