### PR TITLE
New Heal Behavior

### DIFF
--- a/Assets/Prefabs/MileyUnit.prefab
+++ b/Assets/Prefabs/MileyUnit.prefab
@@ -63,6 +63,7 @@ GameObject:
   - 4: {fileID: 491698}
   - 114: {fileID: 11470696}
   - 114: {fileID: 11404160}
+  - 114: {fileID: 11432776}
   m_Layer: 8
   m_Name: MileyUnit
   m_TagString: Untagged
@@ -221,6 +222,19 @@ MonoBehaviour:
   musicVolume: 0.2
   WreckingBallSprite: {fileID: 101030, guid: d4ec8621268ad144e8b67a37d7e5c2eb, type: 2}
   damage: 50
+--- !u!114 &11432776
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 161762}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7676464d4a0c8470b87f042310566b45, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  amount: 20
+  range: 1
 --- !u!114 &11446364
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -275,9 +289,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f627d936eeccb402985988debdfe19d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  HitPoints: 100
-  AttackRange: 3
-  AttackFactor: 100
+  HitPoints: 80
+  AttackRange: 1
+  AttackFactor: 20
   DefenceFactor: 50
   MovementPoints: 4
   MovementSpeed: 8
@@ -286,6 +300,7 @@ MonoBehaviour:
   ColorButton: 4
   unitColor: {r: 0.99264705, g: 0.62619317, b: 0, a: 0.978}
   hopHeight: 1
+  critDefendPercent: 0.8
   characterName: Miley Cyrus
   description: Healer
 --- !u!124 &12448930
@@ -419,6 +434,30 @@ Prefab:
     - target: {fileID: 0}
       propertyPath: musicVolume
       value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: HitPoints
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: AttackRange
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: AttackFactor
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: critDefendPercent
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: amount
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: range
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}

--- a/Assets/scripts/Healer.cs
+++ b/Assets/scripts/Healer.cs
@@ -1,0 +1,73 @@
+﻿using UnityEngine;
+using System.Collections.Generic;
+using Frictionless;
+
+/// <summary>
+/// Units with this component are capable of healing other units
+/// </summary>
+public class Healer : MonoBehaviour {
+
+	public int amount; // Amount to heal
+	public int range; // Range of heal
+
+	private MelodyUnit unit;
+
+	void Start() {
+		unit = GetComponent<MelodyUnit> ();
+	}
+
+	/// <summary>
+	/// This function is called from UnitManager upon receiving an ATTACK action if the unit is a Healer type. It 
+	/// attempts to find a nearby unit on the same team to heal and initiates a "battle" if it finds a unit. If it
+	/// does not, it returns false, and control can be passed to attack code elsewhere.
+	/// </summary>
+	/// <param name="color">Color.</param>
+	public bool OnHealAction(InputButton color) {
+		if (unit.ActionPoints <= 0)
+			return false;
+		
+		CMCellGrid board = ServiceFactory.Instance.Resolve<CellGrid> () as CMCellGrid;
+		MelodyUnit recipient = null;
+
+		if (color == InputButton.NONE) {
+			List<Unit> recipients = board.Units.FindAll (c => (c != unit) && (c.PlayerNumber == unit.PlayerNumber) &&
+			                        (Mathf.Abs (unit.Cell.OffsetCoord [0] - c.Cell.OffsetCoord [0])) +
+			                        (Mathf.Abs (unit.Cell.OffsetCoord [1] - c.Cell.OffsetCoord [1])) <= range);
+			if (recipients.Count == 0)
+				return false;
+			int lowestValue = int.MaxValue;
+			foreach (Unit r in recipients) {
+				if (r.HitPoints < lowestValue) {
+					recipient = r as MelodyUnit;
+					lowestValue = r.HitPoints;
+				}
+			}
+			if (recipient.HitPoints == recipient.MaxHitPoints)
+				return false;
+		} else {
+			recipient = board.Units.Find (c => (c.PlayerNumber == unit.PlayerNumber) &&
+			((c as MelodyUnit).ColorButton == color) &&
+			(Mathf.Abs (unit.Cell.OffsetCoord [0] - c.Cell.OffsetCoord [0])) +
+			(Mathf.Abs (unit.Cell.OffsetCoord [1] - c.Cell.OffsetCoord [1])) <= range) as MelodyUnit;
+			if (recipient == null)
+				return false;
+		}
+		ServiceFactory.Instance.Resolve<MessageRouter> ().RaiseMessage (new EnterBattleMessage () {
+			AttackingUnit = unit,
+			DefendingUnit = recipient,
+			battleType = BattleType.HEAL
+		});
+		return true;
+	}
+
+	public void Heal(MelodyUnit other, float healModifier) {
+		unit.MarkAsAttacking(other);
+		unit.ActionPoints--;
+		other.Replenish (unit, (int)Mathf.Round (amount * healModifier));
+
+		if (unit.ActionPoints == 0) {
+			unit.SetState(new UnitStateMarkedAsFinished(unit));
+			unit.MovementPoints = 0;
+		}
+	}
+}

--- a/Assets/scripts/Healer.cs.meta
+++ b/Assets/scripts/Healer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7676464d4a0c8470b87f042310566b45
+timeCreated: 1456978216
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/scripts/MelodyUnit.cs
+++ b/Assets/scripts/MelodyUnit.cs
@@ -29,6 +29,7 @@ public class MelodyUnit : Unit {
 	public Color unitColor;
 	public MessageRouter MessageRouter;
 	public float hopHeight = 10;
+	public int MaxHitPoints { get { return maxHitPoints; } }
 	private int maxHitPoints;
 	public float critDefendPercent = 0.5f;
 	public string characterName;
@@ -73,10 +74,11 @@ public class MelodyUnit : Unit {
 			OnDestroyed();
 	}
 
-	void Replenish(Unit other, int damage, float defenseModifier) {
+	public void Replenish(Unit other, int amount) {
 		MarkAsDefending(other);
-		int replenish_amount = Mathf.Min(20, maxHitPoints - HitPoints);
+		int replenish_amount = Math.Min (amount, maxHitPoints - HitPoints);
 		HitPoints += replenish_amount;
+
 		MessageRouter.RaiseMessage (new ExitHealMessage () {
 			Replenish = replenish_amount,
 			Recipient = this
@@ -161,24 +163,6 @@ public class MelodyUnit : Unit {
 		MarkAsAttacking(other);
 		ActionPoints--;
 		other.Defend(this, (int) (AttackFactor * attackModifier), DefenseModifier);
-
-		if (ActionPoints == 0)
-		{
-			SetState(new UnitStateMarkedAsFinished(this));
-			MovementPoints = 0;
-		}  
-	}
-
-	public void Heal(MelodyUnit other, float attackModifier, float DefenseModifier)
-	{
-		if (isMoving)
-			return;
-		if (ActionPoints == 0)
-			return;
-
-		MarkAsAttacking(other);
-		ActionPoints--;
-		other.Replenish(this, (int) (AttackFactor * attackModifier), DefenseModifier);
 
 		if (ActionPoints == 0)
 		{

--- a/Assets/scripts/Target.cs
+++ b/Assets/scripts/Target.cs
@@ -69,6 +69,8 @@ public class Target : MonoBehaviour {
 	}
 
 	void OnEnterBattle(EnterBattleMessage m) {
+		if (m.battleType == BattleType.HEAL && m.AttackingUnit.PlayerNumber != player)
+			return; // Don't show other player's targets during heal-battle
 		spriteRenderer.enabled = true;
 	}
 


### PR DESCRIPTION
This is what you might call a "sweeping change." I basically did 3 things that I could not separate into different commits because they are all linked:
1. Made a new Healer script that can be attached to any unit prefab to give them the ability to heal friendly units upon using attack.
2. Made Miley able to attack (Miley's AttackFactor field determines her attack power, instead of determining her heal power, as was previously).
3. Made healing initiate a special one-player battle where the percentage of notes hit affects the amount that the healer heals the target "defending" unit. Entering a battle now passes a BattleType enum, which for now is either ATTACK or HEAL. Note that this change means that you can no longer heal and attack in the same turn. Once we address #215 and both units involved in a battle do damage, this will feel more balanced.

BattleManager.cs has been changed extensively to separate out the two types of player data that was previously in the old PlayerBattleData class. Now, PlayerBattleData contains temporary data describing the two players engaged in the current battle, which is reset at the start of each battle. AllPlayersData contains the persisting data like player difficulty. This change, apart from making more sense, is what allows the single-player healing battle screen to work.

closes #214
closes #219
