### PR TITLE
Pre-baked Lighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@
 *.ogg filter=lfs diff=lfs merge=lfs -crlf
 *.mid filter=lfs diff=lfs merge=lfs -crlf
 *.bytes filter=lfs diff=lfs merge=lfs -text
+*.exr filter=lfs diff=lfs merge=lfs -crlf
+*.asset filter=lfs diff=lfs merge=lfs -crlf

--- a/Assets/CharacterSelect.meta
+++ b/Assets/CharacterSelect.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: e96f73ac4f9264b16b607657378a1a68
+folderAsset: yes
+timeCreated: 1457155572
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CharacterSelect.unity
+++ b/Assets/CharacterSelect.unity
@@ -41,7 +41,7 @@ RenderSettings:
 LightmapSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 6
-  m_GIWorkflowMode: 0
+  m_GIWorkflowMode: 1
   m_LightmapsMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -66,7 +66,8 @@ LightmapSettings:
     m_FinalGather: 0
     m_FinalGatherRayCount: 1024
     m_ReflectionCompression: 2
-  m_LightingDataAsset: {fileID: 0}
+  m_LightingDataAsset: {fileID: 112000001, guid: 069aab1437c9f431bb83b6ee69c87195,
+    type: 2}
   m_RuntimeCPUUsage: 25
 --- !u!196 &4
 NavMeshSettings:
@@ -536,7 +537,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   PlayerNumber: 1
-  WhammyThreshold: 20
 --- !u!114 &428337812
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -549,7 +549,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   PlayerNumber: 0
-  WhammyThreshold: 20
 --- !u!1 &697782509
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/CharacterSelect/LightingData.asset
+++ b/Assets/CharacterSelect/LightingData.asset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca4c2b8564a27e011fc016eb3b76e2d94e386854930266c49c18f962577bf83b
+size 11988

--- a/Assets/CharacterSelect/LightingData.asset.meta
+++ b/Assets/CharacterSelect/LightingData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 069aab1437c9f431bb83b6ee69c87195
+timeCreated: 1457155573
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CharacterSelect/ReflectionProbe-0.exr
+++ b/Assets/CharacterSelect/ReflectionProbe-0.exr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f06e2bf6cfa711ad3b43b44797518c1b738bc94ae5bad3de9bb77c4213d93c2a
+size 139223

--- a/Assets/CharacterSelect/ReflectionProbe-0.exr.meta
+++ b/Assets/CharacterSelect/ReflectionProbe-0.exr.meta
@@ -1,0 +1,58 @@
+fileFormatVersion: 2
+guid: 01fa91e2c4b314bb1b5585bd1693a9b9
+timeCreated: 1457155573
+licenseType: Free
+TextureImporter:
+  fileIDToRecycleName:
+    8900000: generatedCubemap
+  serializedVersion: 2
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    linearTexture: 0
+    correctGamma: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 1
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
+  seamlessCubemap: 1
+  textureFormat: -1
+  maxTextureSize: 2048
+  textureSettings:
+    filterMode: 2
+    aniso: 0
+    mipBias: 0
+    wrapMode: 1
+  nPOTScale: 1
+  lightmap: 0
+  rGBM: 0
+  compressionQuality: 100
+  allowsAlphaSplitting: 0
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spritePixelsToUnits: 100
+  alphaIsTransparency: 0
+  textureType: 3
+  buildTargetSettings: []
+  spriteSheet:
+    sprites: []
+    outline: []
+  spritePackingTag: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Movement.meta
+++ b/Assets/Movement.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b37a6b4293b3e4a46a3a5f8d4b09c27b
+folderAsset: yes
+timeCreated: 1457155608
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Movement.unity
+++ b/Assets/Movement.unity
@@ -41,7 +41,7 @@ RenderSettings:
 LightmapSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 6
-  m_GIWorkflowMode: 0
+  m_GIWorkflowMode: 1
   m_LightmapsMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -66,7 +66,8 @@ LightmapSettings:
     m_FinalGather: 0
     m_FinalGatherRayCount: 1024
     m_ReflectionCompression: 2
-  m_LightingDataAsset: {fileID: 0}
+  m_LightingDataAsset: {fileID: 112000001, guid: ace021f40c1494d5fab726763a0cf6a2,
+    type: 2}
   m_RuntimeCPUUsage: 25
 --- !u!196 &4
 NavMeshSettings:

--- a/Assets/Movement/LightingData.asset
+++ b/Assets/Movement/LightingData.asset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c1e7f6aa2ca1e3d622a1b462adf01cbc12fcc05e3703aad1bea55bf246799ea
+size 11988

--- a/Assets/Movement/LightingData.asset.meta
+++ b/Assets/Movement/LightingData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ace021f40c1494d5fab726763a0cf6a2
+timeCreated: 1457155609
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Movement/ReflectionProbe-0.exr
+++ b/Assets/Movement/ReflectionProbe-0.exr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b351830c2a9fc3a646f5d686aa2ffdf15021a422ff7291eb82f41288e53b6ae3
+size 123813

--- a/Assets/Movement/ReflectionProbe-0.exr.meta
+++ b/Assets/Movement/ReflectionProbe-0.exr.meta
@@ -1,0 +1,58 @@
+fileFormatVersion: 2
+guid: 3d3dff544e68e41e1b4d508114dae916
+timeCreated: 1457155609
+licenseType: Free
+TextureImporter:
+  fileIDToRecycleName:
+    8900000: generatedCubemap
+  serializedVersion: 2
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    linearTexture: 0
+    correctGamma: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 1
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
+  seamlessCubemap: 1
+  textureFormat: -1
+  maxTextureSize: 2048
+  textureSettings:
+    filterMode: 2
+    aniso: 0
+    mipBias: 0
+    wrapMode: 1
+  nPOTScale: 1
+  lightmap: 0
+  rGBM: 0
+  compressionQuality: 100
+  allowsAlphaSplitting: 0
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spritePixelsToUnits: 100
+  alphaIsTransparency: 0
+  textureType: 3
+  buildTargetSettings: []
+  spriteSheet:
+    sprites: []
+    outline: []
+  spritePackingTag: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The lighting bug is due to automatic baking. We can either a) ignore it, since lighting is baked upon building the game so it's not an issue in the final built game, or b) disable automatic baking with the downside of having to keep in mind we'll need to remember to manually bake the lighting any time we add/remove/change a light.

This pull requests adds the baked-in lighting data.

fixes #208 
